### PR TITLE
Share a Candy with an Intent

### DIFF
--- a/app/src/main/java/com/pluralsight/candycoded/DetailActivity.java
+++ b/app/src/main/java/com/pluralsight/candycoded/DetailActivity.java
@@ -71,6 +71,7 @@ public class DetailActivity extends AppCompatActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
+        createShareIntent();
         return super.onOptionsItemSelected(item);
     }
 

--- a/app/src/main/java/com/pluralsight/candycoded/DetailActivity.java
+++ b/app/src/main/java/com/pluralsight/candycoded/DetailActivity.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -68,7 +69,8 @@ public class DetailActivity extends AppCompatActivity {
         return true;
     }
 
-    // ***
-    // TODO - Task 4 - Share the Current Candy with an Intent
-    // ***
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        return super.onOptionsItemSelected(item);
+    }
 }

--- a/app/src/main/java/com/pluralsight/candycoded/DetailActivity.java
+++ b/app/src/main/java/com/pluralsight/candycoded/DetailActivity.java
@@ -73,4 +73,9 @@ public class DetailActivity extends AppCompatActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         return super.onOptionsItemSelected(item);
     }
+
+    private void createShareIntent() {
+        Intent shareIntent = new Intent(Intent.ACTION_SEND);
+        shareIntent.setType("text/plain");
+    }
 }

--- a/app/src/main/java/com/pluralsight/candycoded/DetailActivity.java
+++ b/app/src/main/java/com/pluralsight/candycoded/DetailActivity.java
@@ -78,5 +78,7 @@ public class DetailActivity extends AppCompatActivity {
     private void createShareIntent() {
         Intent shareIntent = new Intent(Intent.ACTION_SEND);
         shareIntent.setType("text/plain");
+        shareIntent.putExtra(Intent.EXTRA_TEXT, SHARE_DESCRIPTION + mCandyImageUrl + HASHTAG_CANDYCODED);
+        startActivity(shareIntent);
     }
 }


### PR DESCRIPTION
- Override onOptionsItemSelected(MenuItem item) in the DetailActivity
- Make createShareIntent()
- Create an ACTION_SEND Intent
- Set the Type for the Intent
- Use putExtra() to Pass Data with the Intent
- Start the Activity